### PR TITLE
GER-426 - Pass expected oldrev to replicator

### DIFF
--- a/org.eclipse.jgit.http.server/pom.xml
+++ b/org.eclipse.jgit.http.server/pom.xml
@@ -57,7 +57,7 @@
 
   <artifactId>org.eclipse.jgit.http.server</artifactId>
   <name>JGit - HTTP Server</name>
-  <version>4.0.1.201506240215-r_WDv6</version>
+  <version>4.0.1.201506240215-r_WDv7</version>
 
   <description>
     Git aware HTTP server implementation.

--- a/org.eclipse.jgit/pom.xml
+++ b/org.eclipse.jgit/pom.xml
@@ -58,7 +58,7 @@
 
   <artifactId>org.eclipse.jgit</artifactId>
   <name>JGit - Core</name>
-  <version>4.0.1.201506240215-r_WDv6</version>
+  <version>4.0.1.201506240215-r_WDv7</version>
 
   <description>
     Repository access and algorithms


### PR DESCRIPTION
- RefUpdate was passing the oldrev as it appears in the filesystem.
- Instead, the oldrev from the client should be sent, if it is
- different from the FS oldrev.

Change-Id: Ibcd7efcd0393f308376294904f0d901a099c3c5b
