### PR TITLE
GER-426 - Use expected rev rather than old rev.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+*.iml

--- a/org.eclipse.jgit.http.server/pom.xml
+++ b/org.eclipse.jgit.http.server/pom.xml
@@ -57,7 +57,7 @@
 
   <artifactId>org.eclipse.jgit.http.server</artifactId>
   <name>JGit - HTTP Server</name>
-  <version>4.0.1.201506240215-r_WDv6</version>
+  <version>4.0.1.201506240215-r_WDv8</version>
 
   <description>
     Git aware HTTP server implementation.

--- a/org.eclipse.jgit/pom.xml
+++ b/org.eclipse.jgit/pom.xml
@@ -58,7 +58,7 @@
 
   <artifactId>org.eclipse.jgit</artifactId>
   <name>JGit - Core</name>
-  <version>4.0.1.201506240215-r_WDv6</version>
+  <version>4.0.1.201506240215-r_WDv8</version>
 
   <description>
     Repository access and algorithms

--- a/org.eclipse.jgit/src/org/eclipse/jgit/lib/RefUpdate.java
+++ b/org.eclipse.jgit/src/org/eclipse/jgit/lib/RefUpdate.java
@@ -491,6 +491,20 @@ public abstract class RefUpdate {
        }
    }
 
+  /**
+   * Get the old ref ID that should be used for passing to the replication engine.
+   *
+   * Where the expected (client) is available, we should use the it over the old rev as it is Git MS and not Gerrit MS that gets the lock
+   * on the git repo in the replicated scenario. This allows us to avoid overwriting commits in a repo which could have been updated
+   * already from another node.
+   *
+   * @return ObjectId that should be used for passing to the replication engine.
+   */
+  private ObjectId getReplicationOldObjectId() {
+    ObjectId clientOldObjectId = getExpectedOldObjectId();
+    return (clientOldObjectId != null) ? clientOldObjectId : getOldObjectId();
+  }
+
    /**
     * Gracefully update the ref to the new value.
     * <p>
@@ -508,8 +522,10 @@ public abstract class RefUpdate {
 
     if (isReplicatedRepo()) {
       doReplicatedUpdate();
+      ObjectId replicateOldObjID = getReplicationOldObjectId();
+
       String name = getName();
-      String oldRef = ObjectId.toString(getOldObjectId());
+      String oldRef = ObjectId.toString(replicateOldObjID);
       String nullRef = ObjectId.toString(ObjectId.zeroId());
       if (name.startsWith("refs/meta/config") || name.startsWith("refs/changes/") || 
               oldRef.equals(nullRef)) {
@@ -518,7 +534,7 @@ public abstract class RefUpdate {
         return Result.NEW;
       } else {        
         RevObject newObj = safeParse(walk, newValue);
-        RevObject oldObj = safeParse(walk, oldValue);
+        RevObject oldObj = safeParse(walk, replicateOldObjID);
         if (walk.isMergedInto((RevCommit) oldObj, (RevCommit) newObj)) {
           return Result.FAST_FORWARD;
         } else {
@@ -709,7 +725,7 @@ public abstract class RefUpdate {
       String user = username.get();
       setUsername(null);
       String fsPath = getRepository().getDirectory().getAbsolutePath();
-      String oldRev = ObjectId.toString(getOldObjectId());
+      String oldRev = ObjectId.toString(getReplicationOldObjectId());
       String newRev = ObjectId.toString(getNewObjectId());
       String[] commandUpdate = { getRpUpdateScript(), getName(), oldRev, newRev};
 


### PR DESCRIPTION
  For replicated updates, we should attempt to use the expected rev
  rather than the old rev as it is gitms and not gerrit who gets the
  ref lock in the replicated scenario.

Change-Id: I2775a6322a2e2185be4181ca0efe2edd61b75b86
